### PR TITLE
bump rust to 1.49

### DIFF
--- a/plan.sh
+++ b/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=rust
 pkg_origin=core
-pkg_version=1.48.0
+pkg_version=1.49.0
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="\
 Rust is a systems programming language that runs blazingly fast, prevents \
@@ -10,7 +10,7 @@ pkg_upstream_url="https://www.rust-lang.org/"
 pkg_license=('Apache-2.0' 'MIT')
 _url_base="https://static.rust-lang.org/dist"
 pkg_source="$_url_base/${pkg_name}-${pkg_version}-x86_64-unknown-linux-gnu.tar.gz"
-pkg_shasum="950420a35b2dd9091f1b93a9ccd5abc026ca7112e667f246b1deb79204e2038b"
+pkg_shasum="8b14446df82f3707d69cf58fed92f18e0bff91621c62baf89288ef70e3e92981"
 pkg_dirname="${pkg_name}-${pkg_version}-x86_64-unknown-linux-gnu"
 pkg_deps=(
   core/glibc
@@ -33,7 +33,7 @@ _target_sources=(
 )
 
 _target_shasums=(
-    "1bf2a0cfaa3e0cf8f743a48802c91d641a3289dffa1c44d7dc5365b68c8739c4"
+    "07d5ebdb6c391631c168deea21c7f4d538ea93c86c2e5e1968508e90835c14e9"
 )
 
 do_download() {


### PR DESCRIPTION
Signed-off-by: Matt Wrock <matt@mattwrock.com>